### PR TITLE
Small fix to deal with a bug in minctracc

### DIFF
--- a/minctracc/Optimize/optimize.c
+++ b/minctracc/Optimize/optimize.c
@@ -979,6 +979,8 @@ VIO_BOOL replace_volume_data_with_ubyte(VIO_Volume data)
   VOXEL_DATA (data) = VOXEL_DATA (tmp_vol);
   
   set_volume_type(data, NC_BYTE, FALSE, 0.0, 0.0);
+  
+  set_volume_real_range(data, min, max);
 
   VOXEL_DATA (tmp_vol) = NULL;  /* is this really necessary?!?!? */
 


### PR DESCRIPTION
This change is designed to fix a bug in minctracc which occurs when
using mutual information (-mi), in which the thresholds are interpreted
in the byte range rather than the real range. Setting the real range
after converstion in this function should solve that problem.
