### PR TITLE
Allow specification of slice dimension to mincblur

### DIFF
--- a/mincblur/blur_volume.c
+++ b/mincblur/blur_volume.c
@@ -88,6 +88,11 @@
 static char rcsid[]="$Header: /static-cvsroot/registration/mni_autoreg/mincblur/blur_volume.c,v 96.5 2009-07-23 22:34:00 claude Exp $";
 #endif
 
+
+#define  VIO_ROW    VIO_X
+#define  VIO_COL    VIO_Y
+#define  VIO_SLICE  VIO_Z
+
 #include <float.h>
 #include <volume_io.h>
 #include <config.h>
@@ -100,8 +105,8 @@ int ms_volume_reals_flag;
 
 void fft1(float *signal, int numpoints, int direction);
 
-VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
-                            double fwhmx, double fwhmy, double fwhmz, 
+VIO_Status blur3D_volume(VIO_Volume data, int rcsv[VIO_MAX_DIMENSIONS],
+                            double *fwhm,
                             char *infile,
                             char *outfile, 
                             FILE *reals_fp,
@@ -157,7 +162,6 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   VIO_Real
     steps[3];                        /* size of voxel step from center to center in x,y,z */
 
-
   /*---------------------------------------------------------------------------------*/
   /*             start by setting up the raw data.                                   */
   /*---------------------------------------------------------------------------------*/
@@ -165,11 +169,11 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   get_volume_sizes(data, sizes);          /* rows,cols,slices */
   get_volume_separations(data, steps);
   
-  slice_size = sizes[xyzv[VIO_X]] * sizes[xyzv[VIO_Y]];    /* sizeof one slice  */
-  col_size   = sizes[xyzv[VIO_Y]];                         /* sizeof one column */
-  row_size   = sizes[xyzv[VIO_X]];                         /* sizeof one row    */
+  slice_size = sizes[rcsv[VIO_ROW]] * sizes[rcsv[VIO_COL]];    /* sizeof one slice  */
+  col_size   = sizes[rcsv[VIO_COL]];                         /* sizeof one column */
+  row_size   = sizes[rcsv[VIO_ROW]];                         /* sizeof one row    */
 
-  total_voxels = sizes[xyzv[VIO_X]]*sizes[xyzv[VIO_Y]]*sizes[xyzv[VIO_Z]];
+  total_voxels = sizes[rcsv[VIO_ROW]]*sizes[rcsv[VIO_COL]]*sizes[rcsv[VIO_SLICE]];
 
   ALLOC(fdata, total_voxels);
 
@@ -185,12 +189,12 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   min_val = FLT_MAX;
 
   f_ptr = fdata;
-  for(slice=0; slice<sizes[xyzv[VIO_Z]]; slice++) {
-    pos[xyzv[VIO_Z]] = slice;
-    for(row=0; row<sizes[xyzv[VIO_Y]]; row++) {
-      pos[xyzv[VIO_Y]] = row;
-      for(col=0; col<sizes[xyzv[VIO_X]]; col++) {
-        pos[xyzv[VIO_X]] = col;
+  for(slice=0; slice<sizes[rcsv[VIO_SLICE]]; slice++) {
+    pos[rcsv[VIO_SLICE]] = slice;
+    for(row=0; row<sizes[rcsv[VIO_COL]]; row++) {
+      pos[rcsv[VIO_COL]] = row;
+      for(col=0; col<sizes[rcsv[VIO_ROW]]; col++) {
+        pos[rcsv[VIO_ROW]] = col;
 
         GET_VOXEL_3D( tmp, data, pos[0], pos[1], pos[2] );
 
@@ -213,8 +217,8 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   /*-----------------------------------------------------------------------------*/
   /*             determine   size of data structures needed                      */
   
-  vector_size_data = sizes[xyzv[VIO_X]]; 
-  kernel_size_data = (int)(((4*fwhmx)/VIO_ABS(steps[xyzv[VIO_X]])) + 0.5);
+  vector_size_data = sizes[rcsv[VIO_ROW]]; 
+  kernel_size_data = (int)(((4*fwhm[rcsv[VIO_ROW]])/VIO_ABS(steps[rcsv[VIO_ROW]])) + 0.5);
   
   if (kernel_size_data > MAX(vector_size_data,256))
     kernel_size_data =  MAX(vector_size_data,256);
@@ -234,7 +238,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   /*                get ready to start up the transformation.                             */
   /*--------------------------------------------------------------------------------------*/
   
-  initialize_progress_report( &progress, FALSE, sizes[xyzv[VIO_Z]] + sizes[xyzv[VIO_Z]] + sizes[xyzv[VIO_X]] + 1,
+  initialize_progress_report( &progress, FALSE, sizes[rcsv[VIO_SLICE]] + sizes[rcsv[VIO_SLICE]] + sizes[rcsv[VIO_ROW]] + 1,
                              "Blurring volume" );
   
   /*--------------------------------------------------------------------------------------*/
@@ -243,30 +247,30 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   
   /*    1st calculate kern array for gaussian kernel*/
   
-  make_kernel(kern,(float)(VIO_ABS(steps[xyzv[VIO_X]])),fwhmx,array_size_pow2,kernel_type);
+  make_kernel(kern,(float)(VIO_ABS(steps[rcsv[VIO_ROW]])),fwhm[rcsv[VIO_ROW]],array_size_pow2,kernel_type);
   fft1(kern,array_size_pow2,1);
   
   /*    calculate offset for original data to be placed in vector            */
   
-  data_offset = (array_size_pow2-sizes[xyzv[VIO_X]])/2;
+  data_offset = (array_size_pow2-sizes[rcsv[VIO_ROW]])/2;
   
   /*    2nd now convolve this kernel with the rows of the dataset            */
   
   slice_limit = 0;
   switch (ndim) {
   case 1: slice_limit = 0; break;
-  case 2: slice_limit = sizes[xyzv[VIO_Z]]; break;
-  case 3: slice_limit = sizes[xyzv[VIO_Z]]; break;
+  case 2: slice_limit = sizes[rcsv[VIO_SLICE]]; break;
+  case 3: slice_limit = sizes[rcsv[VIO_SLICE]]; break;
   }
 
   for (slice = 0; slice < slice_limit; slice++) {      /* for each slice */
     
-    for (row = 0; row < sizes[xyzv[VIO_Y]]; row++) {           /* for each row   */
+    for (row = 0; row < sizes[rcsv[VIO_COL]]; row++) {           /* for each row   */
       
-      f_ptr = fdata + slice*slice_size + row*sizes[xyzv[VIO_X]];
+      f_ptr = fdata + slice*slice_size + row*sizes[rcsv[VIO_ROW]];
       memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(float));
       
-      for (col=0; col< sizes[xyzv[VIO_X]]; col++) {        /* extract the row */
+      for (col=0; col< sizes[rcsv[VIO_ROW]]; col++) {        /* extract the row */
         dat_vector[1 +2*(col+data_offset)  ] = *f_ptr++;
       }
       
@@ -274,8 +278,8 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
       muli_vects(dat_vecto2,dat_vector,kern,array_size_pow2);
       fft1(dat_vecto2,array_size_pow2,-1);
       
-      f_ptr = fdata + slice*slice_size + row*sizes[xyzv[VIO_X]];
-      for (col=0; col< sizes[xyzv[VIO_X]]; col++) {        /* put the row back */
+      f_ptr = fdata + slice*slice_size + row*sizes[rcsv[VIO_ROW]];
+      for (col=0; col< sizes[rcsv[VIO_ROW]]; col++) {        /* put the row back */
         
         vindex = 1 + 2*(col+data_offset);
         
@@ -305,8 +309,8 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   
   f_ptr = fdata;
   
-  vector_size_data = sizes[xyzv[VIO_Y]];
-  kernel_size_data = (int)(((4*fwhmy)/(VIO_ABS(steps[xyzv[VIO_Y]]))) + 0.5);
+  vector_size_data = sizes[rcsv[VIO_COL]];
+  kernel_size_data = (int)(((4*fwhm[rcsv[VIO_COL]])/(VIO_ABS(steps[rcsv[VIO_COL]]))) + 0.5);
   
   if (kernel_size_data > MAX(vector_size_data,256))
     kernel_size_data =  MAX(vector_size_data,256);
@@ -326,25 +330,25 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   
   /*    1st calculate kern array for gaussian kernel*/
   
-  make_kernel(kern,(float)(VIO_ABS(steps[xyzv[VIO_Y]])),fwhmy,array_size_pow2,kernel_type);
+  make_kernel(kern,(float)(VIO_ABS(steps[rcsv[VIO_COL]])),fwhm[rcsv[VIO_COL]],array_size_pow2,kernel_type);
   fft1(kern,array_size_pow2,1);
   
   /*    calculate offset for original data to be placed in vector            */
   
-  data_offset = (array_size_pow2-sizes[xyzv[VIO_Y]])/2;
+  data_offset = (array_size_pow2-sizes[rcsv[VIO_COL]])/2;
   
   /*    2nd now convolve this kernel with the rows of the dataset            */
   
   switch (ndim) {
   case 1: slice_limit = 0; break;
-  case 2: slice_limit = sizes[xyzv[VIO_Z]]; break;
-  case 3: slice_limit = sizes[xyzv[VIO_Z]]; break;
+  case 2: slice_limit = sizes[rcsv[VIO_SLICE]]; break;
+  case 3: slice_limit = sizes[rcsv[VIO_SLICE]]; break;
   }
 
 
   for (slice = 0; slice < slice_limit; slice++) {      /* for each slice */
     
-    for (col = 0; col < sizes[xyzv[VIO_X]]; col++) {           /* for each col   */
+    for (col = 0; col < sizes[rcsv[VIO_ROW]]; col++) {           /* for each col   */
       
       /*         f_ptr = fdata + slice*slice_size + row*sizeof(float); */
       
@@ -353,7 +357,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
       
       memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(float));
       
-      for (row=0; row< sizes[xyzv[VIO_Y]]; row++) {        /* extract the col */
+      for (row=0; row< sizes[rcsv[VIO_COL]]; row++) {        /* extract the col */
         dat_vector[1 +2*(row+data_offset) ] = *f_ptr;
         f_ptr += row_size;
       }
@@ -364,7 +368,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
       fft1(dat_vecto2,array_size_pow2,-1);
       
       f_ptr = fdata + slice*slice_size + col;
-      for (row=0; row< sizes[xyzv[VIO_Y]]; row++) {        /* put the col back */
+      for (row=0; row< sizes[rcsv[VIO_COL]]; row++) {        /* put the col back */
         
         vindex = 1 + 2*(row+data_offset);
         
@@ -376,7 +380,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
       }
       
     }
-    update_progress_report( &progress, slice+sizes[xyzv[VIO_Z]]+1 );
+    update_progress_report( &progress, slice+sizes[rcsv[VIO_SLICE]]+1 );
     
   }
   
@@ -396,8 +400,8 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   
   f_ptr = fdata;
   
-  vector_size_data = sizes[xyzv[VIO_Z]];
-  kernel_size_data = (int)(((4*fwhmz)/(VIO_ABS(steps[xyzv[VIO_Z]]))) + 0.5);
+  vector_size_data = sizes[rcsv[VIO_SLICE]];
+  kernel_size_data = (int)(((4*fwhm[rcsv[VIO_SLICE]])/(VIO_ABS(steps[rcsv[VIO_SLICE]]))) + 0.5);
   
   if (kernel_size_data > MAX(vector_size_data,256))
     kernel_size_data =  MAX(vector_size_data,256);
@@ -421,25 +425,25 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
     
     /*    1st calculate kern array for gaussian kernel*/
     
-    make_kernel(kern,(float)(VIO_ABS(steps[xyzv[VIO_Z]])),fwhmz,array_size_pow2,kernel_type);
+    make_kernel(kern,(float)(VIO_ABS(steps[rcsv[VIO_SLICE]])),fwhm[rcsv[VIO_SLICE]],array_size_pow2,kernel_type);
     fft1(kern,array_size_pow2,1);
     
     /*    calculate offset for original data to be placed in vector            */
     
-    data_offset = (array_size_pow2-sizes[xyzv[VIO_Z]])/2;
+    data_offset = (array_size_pow2-sizes[rcsv[VIO_SLICE]])/2;
     
     
     /*    2nd now convolve this kernel with the slices of the dataset            */
     
-    for (col = 0; col < sizes[xyzv[VIO_X]]; col++) {      /* for each column */
+    for (col = 0; col < sizes[rcsv[VIO_ROW]]; col++) {      /* for each column */
       
-      for (row = 0; row < sizes[xyzv[VIO_Y]]; row++) {           /* for each row   */
+      for (row = 0; row < sizes[rcsv[VIO_COL]]; row++) {           /* for each row   */
         
         f_ptr = fdata + col*col_size + row;
         
         memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(float));
         
-        for (slice=0; slice< sizes[xyzv[VIO_Z]]; slice++) {        /* extract the slice vector */
+        for (slice=0; slice< sizes[rcsv[VIO_SLICE]]; slice++) {        /* extract the slice vector */
           dat_vector[1 +2*(slice+data_offset) ] = *f_ptr;
           f_ptr += slice_size;
         }
@@ -451,7 +455,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
         
         f_ptr = fdata + col*col_size + row;
         
-        for (slice=0; slice< sizes[xyzv[VIO_Z]]; slice++) {        /* put the vector back */
+        for (slice=0; slice< sizes[rcsv[VIO_SLICE]]; slice++) {        /* put the vector back */
           
           vindex = 1 + 2*(slice+data_offset);
           
@@ -465,7 +469,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
         
         
       }
-      update_progress_report( &progress, col + 2*sizes[xyzv[VIO_Z]] + 1 );
+      update_progress_report( &progress, col + 2*sizes[rcsv[VIO_SLICE]] + 1 );
       
     }
     
@@ -473,8 +477,8 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   else {
 
     for (slice = 0; slice < slice_limit; slice++) {      /* for each slice */
-      for (col = 0; col < sizes[xyzv[VIO_X]]; col++) {             /* for each column */
-        for (row = 0; row < sizes[xyzv[VIO_Y]]; row++) {           /* for each row   */
+      for (col = 0; col < sizes[rcsv[VIO_ROW]]; col++) {             /* for each column */
+        for (row = 0; row < sizes[rcsv[VIO_COL]]; row++) {           /* for each row   */
           if (max_val<*f_ptr) max_val = *f_ptr;
           if (min_val>*f_ptr) min_val = *f_ptr;
           f_ptr++;
@@ -506,12 +510,12 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   set_volume_real_range(data, min_val, max_val);
 
   printf("Making byte volume...\n" );
-  for(slice=0; slice<sizes[xyzv[VIO_Z]]; slice++) {
-    pos[xyzv[VIO_Z]] = slice;
-    for(row=0; row<sizes[xyzv[VIO_Y]]; row++) {
-      pos[xyzv[VIO_Y]] = row;
-      for(col=0; col<sizes[xyzv[VIO_X]]; col++) {
-        pos[xyzv[VIO_X]] = col;
+  for(slice=0; slice<sizes[rcsv[VIO_SLICE]]; slice++) {
+    pos[rcsv[VIO_SLICE]] = slice;
+    for(row=0; row<sizes[rcsv[VIO_COL]]; row++) {
+      pos[rcsv[VIO_COL]] = row;
+      for(col=0; col<sizes[rcsv[VIO_ROW]]; col++) {
+        pos[rcsv[VIO_ROW]] = col;
         tmp = CONVERT_VALUE_TO_VOXEL(data, *f_ptr);
          SET_VOXEL_3D( data, pos[0], pos[1], pos[2], tmp);
         f_ptr++;

--- a/mincblur/mincblur.c
+++ b/mincblur/mincblur.c
@@ -153,7 +153,29 @@ void get_volume_XYZV_indices(VIO_Volume data, int xyzv[]) {
 
   delete_dimension_names(data, data_dim_names);
 }
-
+void XYZV_to_RCSV_indices(VIO_Volume data, int xyzv[], int rcsv[]) {
+  int i;
+  
+  for(i=0; i<VIO_N_DIMENSIONS+1; i++) rcsv[i] = xyzv[i];
+  if ( equal_strings(slice_dim, "xspace") ){
+    rcsv[0] = xyzv[2];
+    rcsv[1] = xyzv[1];
+    rcsv[2] = xyzv[0];
+  }
+  else if ( equal_strings(slice_dim, "yspace") ){
+    rcsv[0] = xyzv[2];
+    rcsv[1] = xyzv[0];
+    rcsv[2] = xyzv[1];
+  }
+  else if ( equal_strings(slice_dim, "zspace") ){
+    rcsv[0] = xyzv[0];
+    rcsv[1] = xyzv[1];
+    rcsv[2] = xyzv[2];
+  }
+  else{
+    print_error_and_line_num ("Could not interpret slice dimension\n", __FILE__, __LINE__);
+  }
+}
 
 int main (int argc, char *argv[] )
 {   
@@ -180,7 +202,8 @@ int main (int argc, char *argv[] )
     n_dimensions,
     i,
     sizes[3],
-    xyzv[VIO_MAX_DIMENSIONS];
+    xyzv[VIO_MAX_DIMENSIONS], // indices of x, y, and z dimensions
+    rcsv[VIO_MAX_DIMENSIONS]; // indices of row, column, slice dimensions
   char *history;
   char *tname;
 
@@ -300,7 +323,12 @@ int main (int argc, char *argv[] )
   if ( status != VIO_OK )
     print_error_and_line_num("problems reading `%s'.\n",__FILE__, __LINE__,infilename);
 
+
+  /* Get indices of x/y/z dimensions */
   get_volume_XYZV_indices( data, xyzv );
+
+  /* Convert to row/col/slice indicies */
+  XYZV_to_RCSV_indices( data, xyzv, rcsv );
 
   if (debug) {
     get_volume_sizes(data, sizes);
@@ -330,8 +358,8 @@ int main (int argc, char *argv[] )
   }
  
                                 /* now _BLUR_ the DATA! */
-  status = blur3D_volume(data, xyzv,
-                         fwhm_3D[0],fwhm_3D[1],fwhm_3D[2],
+  status = blur3D_volume(data, rcsv,
+                         fwhm_3D,
                          infilename,
                          output_basename,
                          reals_fp,
@@ -359,7 +387,7 @@ int main (int argc, char *argv[] )
       partials_name = temp_basename;
 
 
-    status = gradient3D_volume(reals_fp, data, xyzv, infilename, partials_name, dimensions,
+    status = gradient3D_volume(reals_fp, data, rcsv, infilename, partials_name, dimensions,
                                history, FALSE);
     if (status!=VIO_OK)
       print_error_and_line_num("Can't calculate the gradient volumes.",__FILE__, __LINE__);

--- a/mincblur/mincblur.h
+++ b/mincblur/mincblur.h
@@ -45,7 +45,7 @@
 ---------------------------------------------------------------------------- */
 
 VIO_Status blur3D_volume(VIO_Volume data, int *xyzv,
-                            double  kernel1, double  kernel2, double  kernel3, 
+                            double  *kernel,
                             char *infile, 
                             char *outfile, 
                             FILE *reals_fp,
@@ -89,6 +89,7 @@ int debug,
   dimensions,
   do_gradient_flag,
   do_partials_flag;
+char *slice_dim = "zspace";
 
 
 ArgvInfo argTable[] = {
@@ -100,6 +101,12 @@ ArgvInfo argTable[] = {
      "Full-width-half-maximum of gaussian kernel"},
   {"-dimensions", ARGV_INT, (char *) 0, (char *) &dimensions,
      "Number of dimensions to blur (either 1,2 or 3)."},
+  {"-xslice", ARGV_CONSTANT, (char *) "xspace", (char *) &slice_dim,
+     "Use xspace as the slice dimension."},
+  {"-yslice", ARGV_CONSTANT, (char *) "yspace", (char *) &slice_dim,
+     "Use yspace as the slice dimension."},
+  {"-zslice", ARGV_CONSTANT, (char *) "zspace", (char *) &slice_dim,
+     "Use zspace as the slice dimension (defaut)."},
   
   {NULL, ARGV_HELP, NULL, NULL,
      "Program flags."},


### PR DESCRIPTION
Currently, mincblur has has hardcoded zspace as the "slice dimension" which has implications when blurring fewer than three dimensions. This commit adds -xslice, -yslice, and -zslice options to mincblur, which sets the overrides the default slice dimension.
