### PR TITLE
Fix argtable so -use_bfgs actually works

### DIFF
--- a/minctracc/Main/globaldefs.h
+++ b/minctracc/Main/globaldefs.h
@@ -179,7 +179,7 @@ ArgvInfo argTable[] = {
   {"-w_shear", ARGV_FLOAT, (char *) 3, 
      (char *) &main_argsX.trans_info.weights[9],
      "Optimization weight of shears a,b and c."},
-  {"-use_bfgs", ARGV_CONSTANT, (char *) FALSE, (char *) &main_argsX.trans_info.use_bfgs,
+  {"-use_bfgs", ARGV_CONSTANT, (char *) TRUE, (char *) &main_argsX.trans_info.use_bfgs,
      "use BFGS optimizer instead of amoeba "},
 
   {NULL, ARGV_HELP, NULL, NULL,


### PR DESCRIPTION
The -use_bfgs option was set to FALSE in argtable, so adding it on a the command line just stored FALSE in the option, meaning it could never be used. Fix this.