### PR TITLE
Bumped precision from float to double

### DIFF
--- a/mincblur/apodize_data.c
+++ b/mincblur/apodize_data.c
@@ -22,9 +22,9 @@
 /* normalized height of 1.0,  given sigma, x and mu         */
 /*  all in mm                                               */
 /************************************************************/
-static float normal_height(float fwhm,float mu,float x)
+static double normal_height(double fwhm,double mu,double x)
 {
-   float sigma,t2,f;
+   double sigma,t2,f;
 
    sigma = fwhm/2.35482;
 
@@ -51,7 +51,7 @@ void apodize_data(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   int
     num_steps,
     row,col,slice;
-  float
+  double
     scale1,scale2, scale;
   
   VIO_Real
@@ -93,8 +93,8 @@ void apodize_data(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
     
       for(slice=0; slice<num_steps; slice++) {
       
-        scale1 = normal_height( ramp1[dim0]*GWID1, 1.25*ramp1[dim0], (float)slice*ABS(step[xyzv[dim0]]));
-        scale2 = normal_height( ramp1[dim0]*GWID2, 0.0, (float)(num_steps - 1 - slice)*ABS(step[xyzv[dim0]]));
+        scale1 = normal_height( ramp1[dim0]*GWID1, 1.25*ramp1[dim0], (double)slice*ABS(step[xyzv[dim0]]));
+        scale2 = normal_height( ramp1[dim0]*GWID2, 0.0, (double)(num_steps - 1 - slice)*ABS(step[xyzv[dim0]]));
         scale = INTERPOLATE( slice/(num_steps-1.0) , scale1, scale2);
 
         for(row=0; row<sizes[xyzv[dim1]]; row++) {
@@ -125,8 +125,8 @@ void apodize_data(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
     
       for(slice=0; slice<num_steps; slice++) {
       
-        scale1 = normal_height( ramp2[dim0]*GWID1, 1.25*ramp2[dim0], (float)slice*ABS(step[xyzv[dim0]]));
-        scale2 = normal_height( ramp2[dim0]*GWID2, 0.0, (float)(num_steps - 1 - slice)*ABS(step[xyzv[dim0]]));
+        scale1 = normal_height( ramp2[dim0]*GWID1, 1.25*ramp2[dim0], (double)slice*ABS(step[xyzv[dim0]]));
+        scale2 = normal_height( ramp2[dim0]*GWID2, 0.0, (double)(num_steps - 1 - slice)*ABS(step[xyzv[dim0]]));
         scale = INTERPOLATE( slice/(num_steps-1.0) , scale1, scale2);
 
         for(row=0; row<sizes[xyzv[dim1]]; row++) {

--- a/mincblur/blur_support.c
+++ b/mincblur/blur_support.c
@@ -31,10 +31,10 @@
 @CREATED    : Wed Jun 23 09:04:34 EST 1993 Louis Collins
 @MODIFIED   : 
 ---------------------------------------------------------------------------- */
-void muli_vects(float *r, float *s1, float *s2, int n)
+void muli_vects(double *r, double *s1, double *s2, int n)
 {
   int i;
-  float r1,i1,r2,i2;
+  double r1,i1,r2,i2;
 
   r++; s1++; s2++; /* all arrays start at r[1],s1[1] and s2[1], where the real
                       part is r[1] and the imag in r[2], and so on... */
@@ -114,9 +114,9 @@ int next_power_of_two(int x)
 /* return the value of the normal dist at x, given c,sigma  */
 /* and mu ----   all in mm                                  */
 /************************************************************/
-float normal_dist(float c, float fwhm, float mu, float x)
+double normal_dist(double c, double fwhm, double mu, double x)
 {
-  float sigma,t1,t2,t3,f;
+  double sigma,t1,t2,t3,f;
   
   sigma = fwhm/2.35482;
   
@@ -152,20 +152,20 @@ float normal_dist(float c, float fwhm, float mu, float x)
 /* return the value of the normal dist at x, given c,sigma  */
 /* and mu ----   all in mm                                  */
 /************************************************************/
-float rect_dist(float c, float fwhm, float mu, float x)
+double rect_dist(double c, double fwhm, double mu, double x)
 {
   
-  float t;
+  double t;
   
   t = x-mu;
   
 /*  t = t<0 ? -t : t ; */
   
   if ( t >= -fwhm/2  && t < fwhm/2 ) {
-    return(  (float) (c/fwhm) );
+    return(  (double) (c/fwhm) );
   }
   else
-    return ( (float) 0.0 );
+    return ( (double) 0.0 );
   
 }
 
@@ -185,16 +185,16 @@ float rect_dist(float c, float fwhm, float mu, float x)
 @MODIFIED   : 
 ---------------------------------------------------------------------------- */
 /************************************************************/
-void make_kernel_FT(float *kern, int size, float vsize)
+void make_kernel_FT(double *kern, int size, double vsize)
 {
   
   int 
     kindex,k;
-  float
+  double
     factor,
     f_sample_size;
   
-  (void)memset(kern,(int)0,(size_t)((2*size+1)*sizeof(float)));
+  (void)memset(kern,(int)0,(size_t)((2*size+1)*sizeof(double)));
   
   f_sample_size = 1.0/(vsize*size);
   factor = -2.0 * PI * f_sample_size;
@@ -237,13 +237,13 @@ void make_kernel_FT(float *kern, int size, float vsize)
 @CREATED    : Wed Jun 23 09:04:34 EST 1993 Louis Collins
 @MODIFIED   : 
 ---------------------------------------------------------------------------- */
-void make_kernel(float *kern, float vsize, float fwhm, int size, int type)
+void make_kernel(double *kern, double vsize, double fwhm, int size, int type)
 {
 
   int kindex,k;
-  float c,r,max;
+  double c,r,max;
 
-  (void)memset(kern,(int)0,(size_t)((2*size+1)*sizeof(float)));
+  (void)memset(kern,(int)0,(size_t)((2*size+1)*sizeof(double)));
   
   for ( k = -size/2; k<size/2; ++k) {
 
@@ -251,8 +251,8 @@ void make_kernel(float *kern, float vsize, float fwhm, int size, int type)
 
 
     switch (type) {
-    case KERN_GAUSSIAN: kern[kindex] = normal_dist(1.0*vsize,fwhm,0.0,(float)(vsize*k)); break;
-    case KERN_RECT:     kern[kindex] = rect_dist(1.0*vsize,fwhm,0.0,(float)(vsize*k)); break;
+    case KERN_GAUSSIAN: kern[kindex] = normal_dist(1.0*vsize,fwhm,0.0,(double)(vsize*k)); break;
+    case KERN_RECT:     kern[kindex] = rect_dist(1.0*vsize,fwhm,0.0,(double)(vsize*k)); break;
     default: 
       {
         (void) fprintf (stderr,"Illegal kernel type = %d\n",type);

--- a/mincblur/blur_support.h
+++ b/mincblur/blur_support.h
@@ -36,12 +36,12 @@
  *
 ---------------------------------------------------------------------------- */
 
-void  muli_vects(float *r, float *s1, float *s2, int n);
+void  muli_vects(double *r, double *s1, double *s2, int n);
 int   next_power_of_two(int x);
-float normal_dist(float c, float fwhm, float mu, float x);
-float rect_dist(float c, float fwhm, float mu, float x);
-void  make_kernel_FT(float *kern, int size, float vsize);
-void  make_kernel(float *kern, float vsize, float fwhm, int size, int type);
+double normal_dist(double c, double fwhm, double mu, double x);
+double rect_dist(double c, double fwhm, double mu, double x);
+void  make_kernel_FT(double *kern, int size, double vsize);
+void  make_kernel(double *kern, double vsize, double fwhm, int size, int type);
 
 
 /*

--- a/mincblur/blur_volume.c
+++ b/mincblur/blur_volume.c
@@ -98,7 +98,7 @@ extern int debug;
 
 int ms_volume_reals_flag;
 
-void fft1(float *signal, int numpoints, int direction);
+void fft1(double *signal, int numpoints, int direction);
 
 VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
                             double fwhmx, double fwhmy, double fwhmz, 
@@ -107,7 +107,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
                             FILE *reals_fp,
                             int kernel_type, char *history)
 { 
-  float 
+  double 
     *fdata,                        /* floating point storage for blurred volume */
     *f_ptr,                        /* pointer to fdata */
     tmp,
@@ -243,7 +243,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   
   /*    1st calculate kern array for gaussian kernel*/
   
-  make_kernel(kern,(float)(VIO_ABS(steps[xyzv[VIO_X]])),fwhmx,array_size_pow2,kernel_type);
+  make_kernel(kern,(double)(VIO_ABS(steps[xyzv[VIO_X]])),fwhmx,array_size_pow2,kernel_type);
   fft1(kern,array_size_pow2,1);
   
   /*    calculate offset for original data to be placed in vector            */
@@ -259,7 +259,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
     for (row = 0; row < sizes[xyzv[VIO_Y]]; row++) {           /* for each row   */
       
       f_ptr = fdata + slice*slice_size + row*sizes[xyzv[VIO_X]];
-      memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(float));
+      memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(double));
       
       for (col=0; col< sizes[xyzv[VIO_X]]; col++) {        /* extract the row */
         dat_vector[1 +2*(col+data_offset)  ] = *f_ptr++;
@@ -321,7 +321,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   
   /*    1st calculate kern array for gaussian kernel*/
   
-  make_kernel(kern,(float)(VIO_ABS(steps[xyzv[VIO_Y]])),fwhmy,array_size_pow2,kernel_type);
+  make_kernel(kern,(double)(VIO_ABS(steps[xyzv[VIO_Y]])),fwhmy,array_size_pow2,kernel_type);
   fft1(kern,array_size_pow2,1);
   
   /*    calculate offset for original data to be placed in vector            */
@@ -337,12 +337,12 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
     
     for (col = 0; col < sizes[xyzv[VIO_X]]; col++) {           /* for each col   */
       
-      /*         f_ptr = fdata + slice*slice_size + row*sizeof(float); */
+      /*         f_ptr = fdata + slice*slice_size + row*sizeof(double); */
       
       f_ptr = fdata + slice*slice_size + col;
       
       
-      memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(float));
+      memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(double));
       
       for (row=0; row< sizes[xyzv[VIO_Y]]; row++) {        /* extract the col */
         dat_vector[1 +2*(row+data_offset) ] = *f_ptr;
@@ -412,7 +412,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
     
     /*    1st calculate kern array for gaussian kernel*/
     
-    make_kernel(kern,(float)(VIO_ABS(steps[xyzv[VIO_Z]])),fwhmz,array_size_pow2,kernel_type);
+    make_kernel(kern,(double)(VIO_ABS(steps[xyzv[VIO_Z]])),fwhmz,array_size_pow2,kernel_type);
     fft1(kern,array_size_pow2,1);
     
     /*    calculate offset for original data to be placed in vector            */
@@ -428,7 +428,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
         
         f_ptr = fdata + col*col_size + row;
         
-        memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(float));
+        memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(double));
         
         for (slice=0; slice< sizes[xyzv[VIO_Z]]; slice++) {        /* extract the slice vector */
           dat_vector[1 +2*(slice+data_offset) ] = *f_ptr;
@@ -485,7 +485,7 @@ VIO_Status blur3D_volume(VIO_Volume data, int xyzv[VIO_MAX_DIMENSIONS],
   FREE(kern);
   
   if (reals_fp != (FILE *)NULL) {
-    status = io_binary_data(reals_fp,WRITE_FILE, fdata, sizeof(float), total_voxels);
+    status = io_binary_data(reals_fp,WRITE_FILE, fdata, sizeof(double), total_voxels);
     if (status != VIO_OK) 
       print_error_and_line_num("problems writing blurred reals data...",__FILE__, __LINE__);
   }

--- a/mincblur/fft.c
+++ b/mincblur/fft.c
@@ -85,9 +85,9 @@ static char rcsid[]="$Header: /static-cvsroot/registration/mni_autoreg/mincblur/
 #include <config.h>
 #include <math.h>
 
-#define PI2 6.28318530717959
+#define PI2 6.2831853071795864769
 
-void fft1(float *signal, int numpoints, int direction)
+void fft1(double *signal, int numpoints, int direction)
 {
   int 
     n, m, mmax, 
@@ -97,7 +97,7 @@ void fft1(float *signal, int numpoints, int direction)
     wp_r,wp_i,
     w_r,w_i,
     angle;
-  float 
+  double 
     temp,
     temp_real,
     temp_imag;

--- a/mincblur/gradient_volume.c
+++ b/mincblur/gradient_volume.c
@@ -81,7 +81,7 @@ static char rcsid[]="$Header: /static-cvsroot/registration/mni_autoreg/mincblur/
 extern int debug;
 
 
-void fft1(float *signal, int numpoints, int direction);
+void fft1(double *signal, int numpoints, int direction);
 
 VIO_Status gradient3D_volume(FILE *ifd, 
                                 VIO_Volume data, 
@@ -93,7 +93,7 @@ VIO_Status gradient3D_volume(FILE *ifd,
                                 int curvature_flg)
 
 { 
-  float 
+  double 
     *fdata,                        /* floating point storage for blurred volume */
     *f_ptr,                        /* pointer to fdata */
     tmp,
@@ -161,7 +161,7 @@ VIO_Status gradient3D_volume(FILE *ifd,
          /* read in data of input file. */
 
   set_file_position(ifd,(long)0);
-  status = io_binary_data(ifd,READ_FILE, fdata, sizeof(float), total_voxels);
+  status = io_binary_data(ifd,READ_FILE, fdata, sizeof(double), total_voxels);
   if (status != VIO_OK)
     print_error_and_line_num("problems reading binary data...\n",__FILE__, __LINE__);
 
@@ -228,7 +228,7 @@ VIO_Status gradient3D_volume(FILE *ifd,
     for (row = 0; row < sizes[rcsv[VIO_Y]]; row++) {           /* for each row   */
       
       f_ptr = fdata + slice*slice_size + row*sizes[rcsv[VIO_X]];
-      memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(float));
+      memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(double));
       
       for (col=0; col< sizes[rcsv[VIO_X]]; col++) {        /* extract the row */
         dat_vector[1 +2*(col+data_offset)  ] = *f_ptr++;
@@ -307,7 +307,7 @@ VIO_Status gradient3D_volume(FILE *ifd,
   
 
   set_file_position(ifd,0);
-  status = io_binary_data(ifd,READ_FILE, fdata, sizeof(float), total_voxels);
+  status = io_binary_data(ifd,READ_FILE, fdata, sizeof(double), total_voxels);
   if (status != VIO_OK)
     print_error_and_line_num("problems reading binary data...\n",__FILE__, __LINE__);
 
@@ -357,12 +357,12 @@ VIO_Status gradient3D_volume(FILE *ifd,
     
     for (col = 0; col < sizes[rcsv[VIO_X]]; col++) {           /* for each col   */
       
-      /*         f_ptr = fdata + slice*slice_size + row*sizeof(float); */
+      /*         f_ptr = fdata + slice*slice_size + row*sizeof(double); */
       
       f_ptr = fdata + slice*slice_size + col;
       
       
-      memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(float));
+      memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(double));
       
       for (row=0; row< sizes[rcsv[VIO_Y]]; row++) {        /* extract the col */
         dat_vector[1 +2*(row+data_offset) ] = *f_ptr;
@@ -441,7 +441,7 @@ VIO_Status gradient3D_volume(FILE *ifd,
 
 
   set_file_position(ifd,0);
-  status = io_binary_data(ifd,READ_FILE, fdata, sizeof(float), total_voxels);
+  status = io_binary_data(ifd,READ_FILE, fdata, sizeof(double), total_voxels);
   if (status != VIO_OK)
     print_error_and_line_num("problems reading binary data...\n",__FILE__, __LINE__);
   f_ptr = fdata;
@@ -485,7 +485,7 @@ VIO_Status gradient3D_volume(FILE *ifd,
         
         f_ptr = fdata + col*col_size + row;
         
-        memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(float));
+        memset(dat_vector,0,(2*array_size_pow2+1)*sizeof(double));
         
         for (slice=0; slice< sizes[rcsv[VIO_Z]]; slice++) {        /* extract the slice vector */
           dat_vector[1 +2*(slice+data_offset) ] = *f_ptr;

--- a/mincblur/mincblur.c
+++ b/mincblur/mincblur.c
@@ -265,7 +265,7 @@ int main (int argc, char *argv[] )
   remove(output_basename);   
 
        /* if any gradient data is needed, then we have to save the blurred
-          volume in float representation, otherwise quantization errors can
+          volume in double representation, otherwise quantization errors can
           mess up the derivatives.  So get temporary file to save 'real data' */
 
   if ((do_partials_flag || do_gradient_flag)) {


### PR DESCRIPTION
Calculations now performed in double precision 

Performing the forwards and inverse FFT while storing values as floats is too inaccurate. (e.g. taking a volume, adding some noise on the order of 10^-6 and blurring the two volumes makes the difference jump up to 10^-4 in some cases).